### PR TITLE
Configurable precision

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -12,7 +12,7 @@ from optparse import OptionParser
 
 import web
 from log import setup_logging, console_logger
-from stats import stats_printer, print_percentile_stats, print_error_report, print_stats
+from stats import stats_printer, print_percentile_stats, print_error_report, print_stats, global_stats
 from inspectlocust import print_task_ratio, get_task_ratio_dict
 from core import Locust, HttpLocust
 from runners import MasterLocustRunner, SlaveLocustRunner, LocalLocustRunner
@@ -228,6 +228,15 @@ def parse_options():
         help="show program's version number and exit"
     )
 
+    # Customize the precision with which request values are saved
+    parser.add_option(
+        '--precision',
+        action='store',
+        dest='precision',
+        default=2,
+        help="how many digits of precision to store for the response time aggregations"
+    )
+
     # Finalize
     # Return three-tuple of parser + the output from parse_args (opt obj, args)
     opts, args = parser.parse_args()
@@ -340,6 +349,9 @@ def main():
     if options.show_version:
         print "Locust %s" % (version,)
         sys.exit(0)
+
+    if options.precision:
+        global_stats.precision = options.precision
 
     locustfile = find_locustfile(options.locustfile)
     if not locustfile:

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -157,21 +157,24 @@ class StatsEntry(object):
         self.min_response_time = min(self.min_response_time, response_time)
         self.max_response_time = max(self.max_response_time, response_time)
 
-        # to avoid to much data that has to be transfered to the master node when
-        # running in distributed mode, we save the response time rounded in a dict
-        # so that 147 becomes 150, 3432 becomes 3400 and 58760 becomes 59000
-        if response_time < 100:
-            rounded_response_time = response_time
-        elif response_time < 1000:
-            rounded_response_time = int(round(response_time, -1))
-        elif response_time < 10000:
-            rounded_response_time = int(round(response_time, -2))
-        else:
-            rounded_response_time = int(round(response_time, -3))
+        rounded_response_time = self._round_response_time(response_time)
 
         # increase request count for the rounded key in response time dict
         self.response_times.setdefault(rounded_response_time, 0)
         self.response_times[rounded_response_time] += 1
+
+    def _round_response_time(self, response_time):
+        # to avoid to much data that has to be transfered to the master node when
+        # running in distributed mode, we save the response time rounded in a dict
+        # so that 147 becomes 150, 3432 becomes 3400 and 58760 becomes 59000
+        if response_time < 100:
+            return response_time
+        elif response_time < 1000:
+            return int(round(response_time, -1))
+        elif response_time < 10000:
+            return int(round(response_time, -2))
+        else:
+            return int(round(response_time, -3))
 
     def log_error(self, error):
         self.num_failures += 1

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -14,7 +14,7 @@ class RequestStatsAdditionError(Exception):
 
 
 class RequestStats(object):
-    def __init__(self):
+    def __init__(self, precision=2):
         self.entries = {}
         self.errors = {}
         self.num_requests = 0
@@ -22,14 +22,15 @@ class RequestStats(object):
         self.max_requests = None
         self.last_request_timestamp = None
         self.start_time = None
-    
+        self.precision = precision
+
     def get(self, name, method):
         """
         Retrieve a StatsEntry instance by name and method
         """
         entry = self.entries.get((name, method))
         if not entry:
-            entry = StatsEntry(self, name, method)
+            entry = StatsEntry(self, name, method, self.precision)
             self.entries[(name, method)] = entry
         return entry
     
@@ -38,7 +39,7 @@ class RequestStats(object):
         Returns a StatsEntry which is an aggregate of all stats entries 
         within entries.
         """
-        total = StatsEntry(self, name, method=None)
+        total = StatsEntry(self, name, method=None, precision=self.precision)
         for r in self.entries.itervalues():
             total.extend(r, full_request_history=full_request_history)
         return total
@@ -102,7 +103,9 @@ class StatsEntry(object):
     
     The keys (the response time in ms) are rounded to store 1, 2, ... 9, 10, 20. .. 90, 
     100, 200 .. 900, 1000, 2000 ... 9000, in order to save memory.
-    
+
+    The amount of rounding is controlled by the precision argument.
+
     This dict is used to calculate the median and percentile response times.
     """
     
@@ -114,11 +117,19 @@ class StatsEntry(object):
     
     last_request_timestamp = None
     """ Time of the last request for this entry """
-    
-    def __init__(self, stats, name, method):
+
+    def __init__(self, stats, name, method, precision=2):
+        """
+        Arguments:
+            stats (RequestStats): The containing RequestStats object.
+            name (str): The name of the request being measured.
+            method (str): The HTTP method being called in the request.
+            precision (int): The number of significant digits to round response times to.
+        """
         self.stats = stats
         self.name = name
         self.method = method
+        self.precision = precision
         self.reset()
     
     def reset(self):
@@ -172,10 +183,10 @@ class StatsEntry(object):
             return 0
 
         num_digits = int(math.log10(response_time)) + 1
-        if num_digits <= 2:
+        if num_digits <= self.precision:
             return response_time
         else:
-            return int(round(response_time, 2 - num_digits))
+            return int(round(response_time, self.precision - num_digits))
 
     def log_error(self, error):
         self.num_failures += 1
@@ -281,11 +292,12 @@ class StatsEntry(object):
             "total_content_length": self.total_content_length,
             "response_times": self.response_times,
             "num_reqs_per_sec": self.num_reqs_per_sec,
+            "precision": self.precision,
         }
     
     @classmethod
     def unserialize(cls, data):
-        obj = cls(None, data["name"], data["method"])
+        obj = cls(None, data["name"], data["method"], data["precision"])
         for key in [
             "last_request_timestamp",
             "start_time",
@@ -436,7 +448,7 @@ def on_slave_report(client_id, data):
         entry = StatsEntry.unserialize(stats_data)
         request_key = (entry.name, entry.method)
         if not request_key in global_stats.entries:
-            global_stats.entries[request_key] = StatsEntry(global_stats, entry.name, entry.method)
+            global_stats.entries[request_key] = StatsEntry(global_stats, entry.name, entry.method, entry.precision)
         global_stats.entries[request_key].extend(entry, full_request_history=True)
         global_stats.last_request_timestamp = max(global_stats.last_request_timestamp, entry.last_request_timestamp)
 

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -1,6 +1,7 @@
 import time
 import gevent
 import hashlib
+import math
 
 import events
 from exception import StopLocust
@@ -167,14 +168,14 @@ class StatsEntry(object):
         # to avoid to much data that has to be transfered to the master node when
         # running in distributed mode, we save the response time rounded in a dict
         # so that 147 becomes 150, 3432 becomes 3400 and 58760 becomes 59000
-        if response_time < 100:
+        if response_time == 0:
+            return 0
+
+        num_digits = int(math.log10(response_time)) + 1
+        if num_digits <= 2:
             return response_time
-        elif response_time < 1000:
-            return int(round(response_time, -1))
-        elif response_time < 10000:
-            return int(round(response_time, -2))
         else:
-            return int(round(response_time, -3))
+            return int(round(response_time, 2 - num_digits))
 
     def log_error(self, error):
         self.num_failures += 1

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -65,7 +65,7 @@ class TestRequestStats(unittest.TestCase):
         self.assertEqual(self.s.num_failures, 1)
         self.assertEqual(self.s.avg_response_time, 420.5)
         self.assertEqual(self.s.median_response_time, 85)
-    
+
     def test_reset_min_response_time(self):
         self.s.reset()
         self.s.log(756, 0)
@@ -97,11 +97,11 @@ class TestRequestStats(unittest.TestCase):
         self.assertEqual(s.num_failures, 3)
         self.assertEqual(s.median_response_time, 38)
         self.assertEqual(s.avg_response_time, 43.2)
-    
+
     def test_serialize_through_message(self):
         """
-        Serialize a RequestStats instance, then serialize it through a Message, 
-        and unserialize the whole thing again. This is done "IRL" when stats are sent 
+        Serialize a RequestStats instance, then serialize it through a Message,
+        and unserialize the whole thing again. This is done "IRL" when stats are sent
         from slaves to master.
         """
         s1 = StatsEntry(self.stats, "test", "GET")
@@ -109,24 +109,34 @@ class TestRequestStats(unittest.TestCase):
         s1.log(20, 0)
         s1.log(40, 0)
         u1 = StatsEntry.unserialize(s1.serialize())
-        
+
         data = Message.unserialize(Message("dummy", s1.serialize(), "none").serialize()).data
         u1 = StatsEntry.unserialize(data)
-        
+
         self.assertEqual(20, u1.median_response_time)
+
+    def test_response_time_rounding(self):
+        self.assertEquals(self.s._round_response_time(0), 0)
+        self.assertEquals(self.s._round_response_time(4), 4)
+        self.assertEquals(self.s._round_response_time(22), 22)
+        self.assertEquals(self.s._round_response_time(123), 120)
+        self.assertEquals(self.s._round_response_time(455), 460)
+        self.assertEquals(self.s._round_response_time(1123), 1100)
+        self.assertEquals(self.s._round_response_time(1455), 1500)
+        self.assertEquals(self.s._round_response_time(12345), 12000)
 
 
 class TestRequestStatsWithWebserver(WebserverTestCase):
     def test_request_stats_content_length(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyLocust()
         locust.client.get("/ultra_fast")
         self.assertEqual(global_stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response"))
         locust.client.get("/ultra_fast")
         self.assertEqual(global_stats.get("/ultra_fast", "GET").avg_content_length, len("This is an ultra fast response"))
-    
+
     def test_request_stats_no_content_length(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
@@ -134,7 +144,7 @@ class TestRequestStatsWithWebserver(WebserverTestCase):
         path = "/no_content_length"
         r = l.client.get(path)
         self.assertEqual(global_stats.get(path, "GET").avg_content_length, len("This response does not have content-length in the header"))
-    
+
     def test_request_stats_no_content_length_streaming(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
@@ -142,41 +152,41 @@ class TestRequestStatsWithWebserver(WebserverTestCase):
         path = "/no_content_length"
         r = l.client.get(path, stream=True)
         self.assertEqual(0, global_stats.get(path, "GET").avg_content_length)
-    
+
     def test_request_stats_named_endpoint(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyLocust()
         locust.client.get("/ultra_fast", name="my_custom_name")
         self.assertEqual(1, global_stats.get("my_custom_name", "GET").num_requests)
-    
+
     def test_request_stats_query_variables(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyLocust()
         locust.client.get("/ultra_fast?query=1")
         self.assertEqual(1, global_stats.get("/ultra_fast?query=1", "GET").num_requests)
-    
+
     def test_request_stats_put(self):
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
-    
+
         locust = MyLocust()
         locust.client.put("/put")
         self.assertEqual(1, global_stats.get("/put", "PUT").num_requests)
-    
+
     def test_request_connection_error(self):
         class MyLocust(HttpLocust):
             host = "http://localhost:1"
-        
+
         locust = MyLocust()
         response = locust.client.get("/", timeout=0.1)
         self.assertEqual(response.status_code, 0)
         self.assertEqual(1, global_stats.get("/", "GET").num_failures)
         self.assertEqual(0, global_stats.get("/", "GET").num_requests)
-    
+
     def test_max_requests(self):
         class MyTaskSet(TaskSet):
             @task
@@ -187,26 +197,26 @@ class TestRequestStatsWithWebserver(WebserverTestCase):
             task_set = MyTaskSet
             min_wait = 1
             max_wait = 1
-            
+
         try:
             from locust.exception import StopLocust
             global_stats.clear_all()
             global_stats.max_requests = 2
-            
+
             l = MyLocust()
             self.assertRaises(StopLocust, lambda: l.task_set(l).run())
             self.assertEqual(2, global_stats.num_requests)
-            
+
             global_stats.clear_all()
             global_stats.max_requests = 2
             self.assertEqual(0, global_stats.num_requests)
-            
+
             l.run()
             self.assertEqual(2, global_stats.num_requests)
         finally:
             global_stats.clear_all()
             global_stats.max_requests = None
-    
+
     def test_max_requests_failed_requests(self):
         class MyTaskSet(TaskSet):
             @task
@@ -214,23 +224,23 @@ class TestRequestStatsWithWebserver(WebserverTestCase):
                 self.client.get("/ultra_fast")
                 self.client.get("/fail")
                 self.client.get("/fail")
-            
+
         class MyLocust(HttpLocust):
             host = "http://127.0.0.1:%i" % self.port
             task_set = MyTaskSet
             min_wait = 1
             max_wait = 1
-            
+
         try:
             from locust.exception import StopLocust
             global_stats.clear_all()
             global_stats.max_requests = 3
-            
+
             l = MyLocust()
             self.assertRaises(StopLocust, lambda: l.task_set(l).run())
             self.assertEqual(1, global_stats.num_requests)
             self.assertEqual(2, global_stats.num_failures)
-            
+
             global_stats.clear_all()
             global_stats.max_requests = 2
             self.assertEqual(0, global_stats.num_requests)
@@ -247,7 +257,7 @@ class MyTaskSet(TaskSet):
     @task(75)
     def root_task(self):
         pass
-    
+
     @task(25)
     class MySubTaskSet(TaskSet):
         @task
@@ -256,7 +266,7 @@ class MyTaskSet(TaskSet):
         @task
         def task2(self):
             pass
-    
+
 class TestInspectLocust(unittest.TestCase):
     def test_get_task_ratio_dict_relative(self):
         ratio = get_task_ratio_dict([MyTaskSet])
@@ -265,7 +275,7 @@ class TestInspectLocust(unittest.TestCase):
         self.assertEqual(0.25, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["ratio"])
         self.assertEqual(0.5, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["tasks"]["task1"]["ratio"])
         self.assertEqual(0.5, ratio["MyTaskSet"]["tasks"]["MySubTaskSet"]["tasks"]["task2"]["ratio"])
-    
+
     def test_get_task_ratio_dict_total(self):
         ratio = get_task_ratio_dict([MyTaskSet], total=True)
         self.assertEqual(1.0, ratio["MyTaskSet"]["ratio"])

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -115,7 +115,7 @@ class TestRequestStats(unittest.TestCase):
 
         self.assertEqual(20, u1.median_response_time)
 
-    def test_response_time_rounding(self):
+    def test_default_response_time_rounding(self):
         self.assertEquals(self.s._round_response_time(0), 0)
         self.assertEquals(self.s._round_response_time(4), 4)
         self.assertEquals(self.s._round_response_time(22), 22)
@@ -124,6 +124,16 @@ class TestRequestStats(unittest.TestCase):
         self.assertEquals(self.s._round_response_time(1123), 1100)
         self.assertEquals(self.s._round_response_time(1455), 1500)
         self.assertEquals(self.s._round_response_time(12345), 12000)
+
+    def test_configurable_response_time_rounding(self):
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 3)._round_response_time(0), 0)
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 3)._round_response_time(4), 4)
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 1)._round_response_time(22), 20)
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 3)._round_response_time(123), 123)
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 1)._round_response_time(455), 500)
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 5)._round_response_time(1123), 1123)
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 3)._round_response_time(1455), 1460)
+        self.assertEquals(StatsEntry(self.stats, "test_entry", "GET", 4)._round_response_time(12345), 12350)
 
 
 class TestRequestStatsWithWebserver(WebserverTestCase):


### PR DESCRIPTION
Use `--precision X` to store `X` digits of response_times.